### PR TITLE
[fix] 커스텀 확장자 개수 제한 로직 생성

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="FrameworkDetectionExcludesConfiguration">
-    <file type="web" url="file://$PROJECT_DIR$" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="openjdk-17" project-jdk-type="JavaSDK" />
-</project>

--- a/src/main/java/com/flow/extension_block/domain/extension/controller/CustomExtensionController.java
+++ b/src/main/java/com/flow/extension_block/domain/extension/controller/CustomExtensionController.java
@@ -57,6 +57,9 @@ public class CustomExtensionController {
         if (customExtensionService.isExist(extensionName)) {
             throw new IllegalStateException("이미 있는 확장자입니다.");
         }
+        if(customExtensionService.getCustomExtensions().size() >= 200) {
+            throw new IllegalStateException("커스텀 확장자 개수는 200을 넘길 수 없습니다.");
+        }
         customExtensionService.save(extensionName);
 
         return BaseResponseDto.<Void>builder()


### PR DESCRIPTION
## 어떤 이유로 PR을 하셨나요?

- [ ] feature
- [x] bug-fix
- [ ] refactor
- [ ] 기타(아래에 자세한 내용 기입해주세요)

### BE 확인사항
- [ ] 포스트맨으로 API 테스트를 진행하셨나요?

## MR Description :page_facing_up:
커스텀 확장자 추가시 200개수를 넘기지 못하도록 설정하였습니다.

## Discussion :speech_balloon:
특이사항 없음